### PR TITLE
Add type checking when displaying release_date

### DIFF
--- a/opdsbrowser.koplugin/main.lua
+++ b/opdsbrowser.koplugin/main.lua
@@ -1639,8 +1639,8 @@ function OPDSBrowser:showHardcoverStandaloneBooks(books, author_name)
     for _, book in ipairs(standalone_books) do
         local display_text = book.title or "Unknown Title"
 
-        -- Add release date
-        if book.release_date and book.release_date ~= "" then
+        -- Add release date (with type checking)
+        if book.release_date and type(book.release_date) == "string" and book.release_date ~= "" then
             display_text = display_text .. " (" .. book.release_date .. ")"
         end
 
@@ -1962,8 +1962,8 @@ function OPDSBrowser:showHardcoverAllBooks(books, author_name)
     for _, book in ipairs(books) do
         local display_text = book.title or "Unknown Title"
 
-        -- Add release date
-        if book.release_date and book.release_date ~= "" then
+        -- Add release date (with type checking)
+        if book.release_date and type(book.release_date) == "string" and book.release_date ~= "" then
             display_text = display_text .. " (" .. book.release_date .. ")"
         end
 


### PR DESCRIPTION
Hardcover API is returning release_date as a function in some cases, causing 'attempt to concatenate field release_date (a function value)' crash.

Changes:
- Check type(book.release_date) == "string" before concatenating
- Apply to both Standalone Books and All Books views
- Prevents crash when release_date is not a string

This complements the earlier sort fix with type checking during display.